### PR TITLE
Add seed photo metadata (data/photos.json)

### DIFF
--- a/data/photos.json
+++ b/data/photos.json
@@ -1,93 +1,93 @@
 [
   {
     "filename": "BDZZ6799.JPG",
-    "title": "Golden Sunrise",
-    "description": "Sunrise over the mountains with mist at dawn.",
-    "tags": ["sunrise","mountains","mist"],
+    "title": "Chasing Sunsets",
+    "description": "There's nothing quite like watching the sky transform into a canvas of colors over the mountains",
+    "tags": ["sunset","mountains","nature", "landscape", "outdoor"],
     "location": "Himalayas, India"
   },
   {
     "filename": "CKQE2744.JPG",
-    "title": "Forest Path",
-    "description": "A peaceful trail in dense forest.",
-    "tags": ["forest","path","nature"],
-    "location": "Aarey Forest, Mumbai"
+    "title": "Tiny Town",
+    "description": "A peaceful trail in beautiful green valley, surrounded by lush foliage. Perfect for a refreshing walk in nature.",
+    "tags": ["forest","path","nature", "village", "houses"],
+    "location": "Binta, Uttarakhand, India"
   },
   {
     "filename": "DODB0943.JPG",
-    "title": "Desert Dunes",
-    "description": "Rolling dunes under golden light.",
-    "tags": ["desert","sand","sunset"],
-    "location": "Thar Desert"
+    "title": "Struggle or Leisure?",
+    "description": "Maybe the sunset doesn't look that beautiful when you're lost in the nature?",
+    "tags": ["green","village","lost", "houses", "sunset"],
+    "location": "Almora, Uttarakhand, India"
   },
   {
     "filename": "ESYZ0253.JPG",
-    "title": "Lake Reflection",
-    "description": "Mirror-like water with mountain reflection.",
-    "tags": ["lake","reflection","water"],
-    "location": "Lake Tahoe, USA"
+    "title": "Green Reflection",
+    "description": "Mirror-like green: Seasonal or All time? Try and find out.",
+    "tags": ["green","reflection","sunrise", "crops", "mist"],
+    "location": "Almora, Uttarakhand, India"
   },
   {
     "filename": "IMG-7169.JPG",
-    "title": "Traveler’s Rest",
-    "description": "Solitary figure resting under a tree in open field.",
-    "tags": ["travel","rest","solitude"],
-    "location": "Rajasthan, India"
+    "title": "Nature's little wonders",
+    "description": "Embracing the beauty of this stunning plant as the sun sets, painting the sky with warm hues.",
+    "tags": ["outdoor","nature","sunset", "flower"],
+    "location": "Uttarakhand, India"
   },
   {
     "filename": "IMG-7554.JPG",
-    "title": "Trail into Woods",
-    "description": "Trail light filtering through dense woods.",
-    "tags": ["woods","trail","light"],
-    "location": "Black Forest, Germany"
+    "title": "College Hostel: Memories built to last",
+    "description": "A place where friendships are forged and memories are made.",
+    "tags": ["friends","memories","light", "hostel", "college"],
+    "location": "Dwarahat, Uttarakhand, India"
   },
   {
     "filename": "IMG-9254.JPG",
-    "title": "City Glow",
-    "description": "City lights and reflections at dusk.",
-    "tags": ["city","lights","dusk"],
-    "location": "New York City, USA"
+    "title": "Golden Hour Glow",
+    "description": "A cute puppy stares with golden spark in his eyes, seeking your friendship.",
+    "tags": ["dog","golden hour","glow", "cute puppy"],
+    "location": "Almora, Uttarakhand, India"
   },
   {
     "filename": "IMG-9270.JPG",
-    "title": "Milky Way",
-    "description": "Stars blazing across the night sky.",
-    "tags": ["night","stars","milkyway"],
-    "location": "Atacama Desert, Chile"
+    "title": "Little Dude",
+    "description": "This black puppy is ready to explore the great outdoors, one paw at a time!",
+    "tags": ["cute","puppy","little dude", "innocent"],
+    "location": "Almora, Uttarakhand, India"
   },
   {
     "filename": "IMG_7361.JPG",
-    "title": "Ocean Wave",
-    "description": "Powerful wave crashing onto shore.",
-    "tags": ["ocean","wave","power"],
-    "location": "Oregon Coast, USA"
+    "title": "Green and Blues",
+    "description": "A mystery unfolds in the interplay of green and blue hues.",
+    "tags": ["blue sky","green land","nature", "landscape", "outdoor"],
+    "location": "Binta, Uttarakhand, India"
   },
   {
     "filename": "PCOJ2741.JPG",
-    "title": "Temple Silhouette",
-    "description": "Silhouette of ancient temple at sunset.",
-    "tags": ["temple","silhouette","sunset"],
-    "location": "Angkor Wat, Cambodia"
+    "title": "Sky or Sea?",
+    "description": "Nothing beats a bright blue sky filled with fluffy clouds and warm sunshine.",
+    "tags": ["outdoor","nature","sky","clouds","sunshine"],
+    "location": "New Delhi, India"
   },
   {
     "filename": "UYQX4798.JPG",
-    "title": "Mountain Peak",
-    "description": "Snow-capped mountain peak above clouds.",
-    "tags": ["mountain","snow","peak"],
-    "location": "Swiss Alps"
+    "title": "Riverside Romeo",
+    "description": "A serene riverside view with majestic mountains in the background. Perfect spot for some quiet reflection.",
+    "tags": ["mountain","river","nature", "landscape", "outdoor"],
+    "location": "Kosi River, Uttarakhand, India"
   },
   {
     "filename": "VFUZ3447.JPG",
-    "title": "Autumn Leaves",
-    "description": "Leaves turning amber and red in autumn forest.",
-    "tags": ["autumn","leaves","forest"],
-    "location": "Vermont, USA"
+    "title": "Green and Greener",
+    "description": "Leaves turning amber and red in golden light. Can you escape the green?",
+    "tags": ["nature","leaves","forest", "mountains", "farming"],
+    "location": "Almora, Uttarakhand, India"
   },
   {
     "filename": "VVUH7678.JPG",
     "title": "Above the Clouds",
-    "description": "Flying above the clouds at sunrise.",
-    "tags": ["clouds","sunrise","sky"],
-    "location": "Over Himalayas"
+    "description": "Flying above the clouds in the clear blue sky.",
+    "tags": ["clouds","nature","sky", "blue"],
+    "location": "New Delhi, India"
   }
 ]


### PR DESCRIPTION
### Summary
Modified JSON data file containing 13 photo metadata entries used by the gallery (filename, title, description, tags, location).

Modified: [photos.json](https://github.com/shubhamranswal/Nazaare/blob/main/data/photos.json)
13 objects, fields: title, description, tags[], location.
Examples: "Chasing Sunsets", "Tiny Town", "Riverside Romeo", etc.

### Impact / Compatibility
Non-breaking. Purely additive seed data — no migrations required.

### Related
Commit: ca7e0885b93317dde9f8003989da553024be3aa5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated photo metadata including titles, descriptions, tags, and location information across the collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->